### PR TITLE
Add --otpauth-url for external OTP application support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,19 @@ Getting a serial's restore code
 	$ bna --restore EU-1234-1234-1234 ABCDE98765
 	Restored serial EU-1234-1234-1234
 
+OTP from Mobile
+---------------
+::
+
+	$ bna --otpauth-url
+	otpauth://totp/Battle.net:EU123412341234:?secret=ASFAS75ASDF75889G9AD7S69AS7697AS&issuer=Battle.net&digits=8
+
+
+Now paste this to your OTP app, or convert to QRCode and scan, or manually enter the secret.
+
+Note: This will not work with "Google Authenticator" as it does not support 8 digits, try "FreeOTP_"
+
+
 Using the python-bna library
 ============================
 
@@ -65,3 +78,6 @@ Getting a token
 		token, time_remaining = bna.get_token(secret=secret)
 		print(token)
 		sleep(time_remaining)
+
+
+.. _FreeOTP: https://fedorahosted.org/freeotp/

--- a/bin/bna
+++ b/bin/bna
@@ -70,6 +70,11 @@ class Authenticator(object):
 			help="prints a serial's restore code and exit"
 		)
 		arguments.add_argument(
+		        "--otpauth-url",
+		        action="store_true",
+		        help="Print standard otpauth URL for use with OTP apps"
+		)
+		arguments.add_argument(
 			"--set-default",
 			action="store_true",
 			dest="setdefault",
@@ -269,6 +274,11 @@ class Authenticator(object):
 		if self.args.restorecode:
 			code = bna.get_restore_code(serial, self._secret)
 			self.print(code)
+			return 0
+
+		if self.args.otpauth_url:
+			url = bna.get_otpauth_url(serial, self._secret)
+			self.print(url)
 			return 0
 
 		# otherwise print the token

--- a/bna.py
+++ b/bna.py
@@ -7,7 +7,9 @@ Specification can be found here:
 Note: Link likely dead. Check webarchive.
 """
 
+import base64
 import hmac
+
 from binascii import hexlify
 from hashlib import sha1
 from http.client import HTTPConnection
@@ -254,6 +256,12 @@ def restore_code_to_bytes(code):
 		ret.append(c)
 
 	return bytes(ret)
+
+
+def get_otpauth_url(serial, secret):
+	code = base64.b32encode(secret).decode()
+	otpurl = "otpauth://totp/Battle.net:{serial}:?secret={secret}&issuer=Battle.net&digits=8".format(serial=serial, secret=code)
+	return otpurl
 
 
 def initiate_paper_restore(serial, host=ENROLL_HOSTS["default"], path=INIT_RESTORE_PATH):


### PR DESCRIPTION
This generates the URL one would need to add their battle.net
authenicator code into a mobile OTP application.  Reducing the users
number of needed applications and making restoration to such
applications simpler.

It would be useful to add QRCode geneartion as well as a seperate
command.