### PR TITLE
Remove extra colon from OTPauth format

### DIFF
--- a/bna.py
+++ b/bna.py
@@ -38,7 +38,7 @@ INIT_RESTORE_PATH = "/enrollment/initiatePaperRestore.htm"
 VALIDATE_RESTORE_PATH = "/enrollment/validatePaperRestore.htm"
 ENROLL_PATH = "/enrollment/enroll.htm"
 
-OTPAUTH_URI_FORMAT = "otpauth://totp/Battle.net:{serial}:?secret={secret}&issuer=Battle.net&digits=8"
+OTPAUTH_URI_FORMAT = "otpauth://totp/Battle.net:{serial}?secret={secret}&issuer=Battle.net&digits=8"
 
 
 class HTTPError(Exception):


### PR DESCRIPTION
Hello,

After attempting to use this library, I found that generated OTPauth URLs showed as "Invalid token" when scanned into FreeOTP. Removing this extra colon allowed FreeOTP to understand the URL, and the generated codes then worked on Battle.NET.

I don't fully understand the OTPauth URL format, but this worked for me, so I figured I'd send in a PR.