### PR TITLE
Add KR region to list of acceptable regions

### DIFF
--- a/bna/http.py
+++ b/bna/http.py
@@ -89,7 +89,7 @@ def request_new_serial(
 	serial = decrypted_response[20:].decode()
 
 	region = serial[:2]
-	if region not in ("CN", "EU", "US"):
+	if region not in ("CN", "EU", "KR", "US"):
 		raise ValueError("Unexpected region: %r" % (region))
 
 	return serial, secret


### PR DESCRIPTION
Fixes #28 

This adds the KR region.  I believe KR is Korea.  Much like the user in Issue #28 i'm in Australia and bna is getting my region as KR.  

I've tested the patch and added an authenticator to my account with no ill effects.

