### PR TITLE
Fix formatting authenticator serial

### DIFF
--- a/bna/utils.py
+++ b/bna/utils.py
@@ -27,7 +27,7 @@ def prettify_serial(serial: str) -> str:
 			raise ValueError("bad serial %r" % (serial))
 		return "%04i" % int((chars))
 
-	return "%s-%s-%s-%s" % (
+	return "%s%s%s%s" % (
 		serial[0:2].upper(),
 		digits(serial[2:6]),
 		digits(serial[6:10]),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,8 +22,8 @@ def test_restore_code():
 
 
 def test_serial():
-	pretty_serial = bna.prettify_serial(SERIAL)
-	assert pretty_serial == "US-1209-1071-1868"
+	pretty_serial = bna.prettify_serial(SERIAL.lower())
+	assert pretty_serial == "US120910711868"
 	assert bna.normalize_serial(pretty_serial) == SERIAL
 
 


### PR DESCRIPTION
Adressing #32 this commit deletes the hyphens in the serial formatter. The official app does not provide a serial for registration anymore, so parsing might have changed on Blizzard's side.
Only when recovering Blizzard gives a serial, but using the supplied copy function gives a string without hyphens as well.

Test for formatting the serial has been adapted (basically just changing region code to uppercase now)