### PR TITLE
Add clear installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ is less secure than keeping the devices separate. Use this at your own risk.
 Configuration is stored in `~/.config/bna/bna.conf`. You can pass a
 different config path with `bna --config=~/.bna.conf` for example.
 
+## Installation
+
+Make sure you have Python 3 installed. Here Python 3 is on the path as
+`python3`.
+
+Set up python virtual environment and activate it inside a directory of your
+choice:
+
+    $ python3 -m venv .env && source ./.env/bin/activate
+
+Install the package
+
+    $ pip install bna
+
+In the activated virtual environment directory, `bna` will be available for
+running commands.
+
+    $ bna --version 
+
+When finished, you can deactivate the virtual environment.
+
+    $ deactivate
+
 
 ### Creating a new authenticator
 


### PR DESCRIPTION
Thanks for providing this library to use, it works well and allows me to keep my one-time passwords in one place. 

I'm adding some installation instructions to make it a little faster for people who are not daily python users to use this library.

I attempted to use `python -m bna` to run from source, but I'm not familiar with https://python-poetry.org/ so I didn't have an easy way to install the dependencies. 

Out of habit I created a virtual environment. Curious what you think. 